### PR TITLE
Feature/15037924 drush options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,4 @@
 /config-local
 
 #Ignore local drush options. 
-/drush/.drush.yml
+/drush/drush.yml

--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,8 @@
 # Ignore /data for local working files that need to be accessible to docker containers.
 /data
 
-# config_split
+# Ignore local config.
 /config-local
+
+#Ignore local drush options. 
+/drush/.drush.yml

--- a/README.md
+++ b/README.md
@@ -55,9 +55,7 @@ Once installed cd to project directory and type `lando` for a list of commands.
    - Import config: `drush cim` (With lando: `lando drush cim`)
    - Grab a login link: `drush uli [user id] -l [local url]` default is user 1. (With lando: `lando drush uli`)
      - See `lando info` for a list of available proxy urls for local lando development.
-     
-     
-     
+
 
 **Ready to work.**
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ Once installed cd to project directory and type `lando` for a list of commands.
    
  - Build the theme:
    - See theme's README.md.
+
+ - Set up local drush options:
+    - `cp drush/example.drush.yml drush/drush.yml`
+ 
  - Run updates:
    - `cd [site directory]` - [site directory] is web for default or web/sites/[multisite].
    - Database updates: `drush updb` (With lando: `lando drush updb`)
@@ -51,6 +55,9 @@ Once installed cd to project directory and type `lando` for a list of commands.
    - Import config: `drush cim` (With lando: `lando drush cim`)
    - Grab a login link: `drush uli [user id] -l [local url]` default is user 1. (With lando: `lando drush uli`)
      - See `lando info` for a list of available proxy urls for local lando development.
+     
+     
+     
 
 **Ready to work.**
 

--- a/drush/example.drush.yml
+++ b/drush/example.drush.yml
@@ -4,3 +4,6 @@
 # Docs at https://github.com/drush-ops/drush/blob/master/examples/example.drush.yml
 #
 # Edit or remove this file as needed.
+
+options:
+  uri: 'http://jcc.lndo.site/'

--- a/drush/example.drush.yml
+++ b/drush/example.drush.yml
@@ -6,4 +6,4 @@
 # Edit or remove this file as needed.
 
 options:
-  uri: 'http://jcc.lndo.site/'
+  uri: 'https://jcc.lndo.site/'


### PR DESCRIPTION
Removed and gitignored drush.yml and replaced with example.drush.yml that has Lando's url settings.

This will allow developers to use any url for local drush.