### PR TITLE
[TW14850757] Header, Logo, Icons, Global Templates Overrides, etc.

### DIFF
--- a/config/block.block.content.yml
+++ b/config/block.block.content.yml
@@ -9,7 +9,7 @@ dependencies:
 id: content
 theme: atrium
 region: content
-weight: 1
+weight: 2
 provider: null
 plugin: system_main_block
 settings:

--- a/config/block.block.main_menu.yml
+++ b/config/block.block.main_menu.yml
@@ -1,0 +1,25 @@
+uuid: 74963173-5225-43c9-9195-8373d98b5289
+langcode: en
+status: true
+dependencies:
+  config:
+    - system.menu.main
+  module:
+    - system
+  theme:
+    - atrium
+id: main_menu
+theme: atrium
+region: header
+weight: 0
+provider: null
+plugin: 'system_menu_block:main'
+settings:
+  id: 'system_menu_block:main'
+  label: 'Main navigation'
+  provider: system
+  label_display: '0'
+  level: 1
+  depth: 0
+  expand_all_items: false
+visibility: {  }

--- a/config/block.block.messages.yml
+++ b/config/block.block.messages.yml
@@ -9,7 +9,7 @@ dependencies:
 id: messages
 theme: atrium
 region: content
-weight: 0
+weight: 1
 provider: null
 plugin: system_messages_block
 settings:

--- a/config/block.block.tabs.yml
+++ b/config/block.block.tabs.yml
@@ -7,7 +7,7 @@ dependencies:
 id: tabs
 theme: atrium
 region: content
-weight: -1
+weight: 0
 provider: null
 plugin: local_tasks_block
 settings:

--- a/config/block.block.title.yml
+++ b/config/block.block.title.yml
@@ -8,8 +8,8 @@ dependencies:
     - atrium
 id: title
 theme: atrium
-region: header
-weight: -3
+region: title
+weight: 0
 provider: null
 plugin: page_title_block
 settings:

--- a/config/block.block.views_block__hero_navigation_block_1.yml
+++ b/config/block.block.views_block__hero_navigation_block_1.yml
@@ -12,7 +12,7 @@ dependencies:
 id: views_block__hero_navigation_block_1
 theme: atrium
 region: node_hero
-weight: -2
+weight: 0
 provider: null
 plugin: 'views_block:hero_navigation-block_1'
 settings:

--- a/web/themes/custom/atrium/atrium.info.yml
+++ b/web/themes/custom/atrium/atrium.info.yml
@@ -6,9 +6,10 @@ base theme: classy
 
 regions:
   header: Header
+  title: Title
   content: Content
   footer: Footer
-  node_hero: "Node Hero"
+  node_hero: 'Node Hero'
 
 libraries:
   - atrium/style

--- a/web/themes/custom/atrium/templates/block/block--system-menu-block--main.html.twig
+++ b/web/themes/custom/atrium/templates/block/block--system-menu-block--main.html.twig
@@ -1,0 +1,21 @@
+{#
+/**
+ * @file
+ * Template for main menu block.
+ */
+#}
+
+{# Note: The .jcc-header_menu--desktop is needed at this level to layout
+properly (parent is flexed).  However this is a duplicate (see content block)
+and may cause issues in the future. #}
+{% embed 'block--system-menu-block.html.twig' with { classes: ['jcc-header_menu--desktop'] } %}
+  {% block prefix %}
+    <div id="js-header_menu--mobile"></div>
+  {% endblock %}
+
+  {% block content %}
+    <div class="jcc-header_menu--desktop slicknav_menu slicknav_menu--desktop">
+      {{ content }}
+    </div>
+  {% endblock %}
+{% endembed %}

--- a/web/themes/custom/atrium/templates/block/block--system-menu-block.html.twig
+++ b/web/themes/custom/atrium/templates/block/block--system-menu-block.html.twig
@@ -1,0 +1,56 @@
+{#
+/**
+ * @file
+ * Theme override for a menu block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: HTML attributes for the containing element.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: HTML attributes for the title element.
+ * - content_attributes: HTML attributes for the content element.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * Headings should be used on navigation menus that consistently appear on
+ * multiple pages. When this menu block's label is configured to not be
+ * displayed, it is automatically made invisible using the 'visually-hidden' CSS
+ * class, which still keeps it visible for screen-readers and assistive
+ * technology. Headings allow screen-reader and keyboard only users to navigate
+ * to or skip the links.
+ * See http://juicystudio.com/article/screen-readers-display-none.php and
+ * http://www.w3.org/TR/WCAG-TECHS/H42.html for more information.
+ */
+#}
+{%
+  set classes = [
+    'block',
+    'block-menu',
+    'navigation',
+    'menu--' ~ derivative_plugin_id|clean_class,
+  ]
+%}
+{% set heading_id = attributes.id ~ '-menu'|clean_id %}
+<nav role="navigation" aria-labelledby="{{ heading_id }}"{{ attributes.addClass(classes)|without('role', 'aria-labelledby') }}>
+  {# Label. If not displayed, we still provide it for screen readers. #}
+  {% if not configuration.label_display %}
+    {% set title_attributes = title_attributes.addClass('visually-hidden') %}
+  {% endif %}
+  {{ title_prefix }}
+  <h2{{ title_attributes.setAttribute('id', heading_id) }}>{{ configuration.label }}</h2>
+  {{ title_suffix }}
+
+  {# Menu. #}
+  {% block content %}
+    {{ content }}
+  {% endblock %}
+</nav>

--- a/web/themes/custom/atrium/templates/block/block--system-menu-block.html.twig
+++ b/web/themes/custom/atrium/templates/block/block--system-menu-block.html.twig
@@ -38,6 +38,8 @@
   'menu--' ~ derivative_plugin_id|clean_class,
 ]|merge(classes|default([])) %}
 {% set heading_id = attributes.id ~ '-menu'|clean_id %}
+
+{% block prefix %}{% endblock %}
 <nav role="navigation" aria-labelledby="{{ heading_id }}"{{ attributes.addClass(classes)|without('role', 'aria-labelledby') }}>
   {# Label. If not displayed, we still provide it for screen readers. #}
   {% if not configuration.label_display %}
@@ -47,8 +49,8 @@
   <h2{{ title_attributes.setAttribute('id', heading_id) }}>{{ configuration.label }}</h2>
   {{ title_suffix }}
 
-  {# Menu. #}
   {% block content %}
     {{ content }}
   {% endblock %}
 </nav>
+{% block suffix %}{% endblock %}

--- a/web/themes/custom/atrium/templates/block/block--system-menu-block.html.twig
+++ b/web/themes/custom/atrium/templates/block/block--system-menu-block.html.twig
@@ -31,14 +31,12 @@
  * http://www.w3.org/TR/WCAG-TECHS/H42.html for more information.
  */
 #}
-{%
-  set classes = [
-    'block',
-    'block-menu',
-    'navigation',
-    'menu--' ~ derivative_plugin_id|clean_class,
-  ]
-%}
+{% set classes = [
+  'block',
+  'block-menu',
+  'navigation',
+  'menu--' ~ derivative_plugin_id|clean_class,
+]|merge(classes|default([])) %}
 {% set heading_id = attributes.id ~ '-menu'|clean_id %}
 <nav role="navigation" aria-labelledby="{{ heading_id }}"{{ attributes.addClass(classes)|without('role', 'aria-labelledby') }}>
   {# Label. If not displayed, we still provide it for screen readers. #}

--- a/web/themes/custom/atrium/templates/block/block.html.twig
+++ b/web/themes/custom/atrium/templates/block/block.html.twig
@@ -1,0 +1,44 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ */
+#}
+{%
+  set classes = [
+    'block',
+    'block-' ~ configuration.provider|clean_class,
+    'block-' ~ plugin_id|clean_class,
+  ]
+%}
+<div{{ attributes.addClass(classes) }}>
+  {{ title_prefix }}
+  {% if label %}
+    <h2{{ title_attributes }}>{{ label }}</h2>
+  {% endif %}
+  {{ title_suffix }}
+  {% block content %}
+    {{ content }}
+  {% endblock %}
+</div>

--- a/web/themes/custom/atrium/templates/block/block.html.twig
+++ b/web/themes/custom/atrium/templates/block/block.html.twig
@@ -25,20 +25,30 @@
  * @see template_preprocess_block()
  */
 #}
-{%
-  set classes = [
-    'block',
-    'block-' ~ configuration.provider|clean_class,
-    'block-' ~ plugin_id|clean_class,
-  ]
-%}
-<div{{ attributes.addClass(classes) }}>
+{% set tag = tag|default('div') %}
+{% set title_tag = title_tag|default('h2') %}
+{% set classes = [
+  'block',
+  bundle ? 'block--' ~ bundle|clean_class,
+  id ? 'block--' ~ id|replace({"_": "-"})|clean_class,
+]|merge(classes|default([])) %}
+
+{% if tag %}
+  <{{ tag }}{{ attributes|without('id').addClass(classes) }}>
+{% endif %}
+
   {{ title_prefix }}
   {% if label %}
-    <h2{{ title_attributes }}>{{ label }}</h2>
+    {% block title %}
+      <{{ title_tag }}{{ title_attributes }}>{{ label }}</{{ title_tag }}>
+    {% endblock %}
   {% endif %}
   {{ title_suffix }}
+
   {% block content %}
     {{ content }}
   {% endblock %}
-</div>
+
+{% if tag %}
+  </{{ tag }}>
+{% endif %}

--- a/web/themes/custom/atrium/templates/field/field--entity-reference-revisions.html.twig
+++ b/web/themes/custom/atrium/templates/field/field--entity-reference-revisions.html.twig
@@ -1,9 +1,0 @@
-{#
-/**
- * @file
- * Template for entity_reference_revisions field type.
- */
-#}
-{%- for item in items -%}
-  {{ item.content }}
-{%- endfor -%}

--- a/web/themes/custom/atrium/templates/field/field.html.twig
+++ b/web/themes/custom/atrium/templates/field/field.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Template for field_title_display field.
+ * Template override for fields.
  */
 #}
 {%- for item in items -%}

--- a/web/themes/custom/atrium/templates/html/html.html.twig
+++ b/web/themes/custom/atrium/templates/html/html.html.twig
@@ -1,0 +1,55 @@
+{#
+/**
+ * @file
+ * Theme override for the basic structure of a single Drupal page.
+ *
+ * Variables:
+ * - logged_in: A flag indicating if user is logged in.
+ * - root_path: The root path of the current page (e.g., node, admin, user).
+ * - node_type: The content type for the current node, if the page is a node.
+ * - head_title: List of text elements that make up the head_title variable.
+ *   May contain one or more of the following:
+ *   - title: The title of the page.
+ *   - name: The name of the site.
+ *   - slogan: The slogan of the site.
+ * - page_top: Initial rendered markup. This should be printed before 'page'.
+ * - page: The rendered page markup.
+ * - page_bottom: Closing rendered markup. This variable should be printed after
+ *   'page'.
+ * - db_offline: A flag indicating if the database is offline.
+ * - placeholder_token: The token for generating head, css, js and js-bottom
+ *   placeholders.
+ *
+ * @see template_preprocess_html()
+ */
+#}
+{%
+  set body_classes = [
+    logged_in ? 'user-logged-in',
+    not root_path ? 'path-frontpage' : 'path-' ~ root_path|clean_class,
+    node_type ? 'page-node-type-' ~ node_type|clean_class,
+    db_offline ? 'db-offline',
+  ]
+%}
+<!DOCTYPE html>
+<html{{ html_attributes }}>
+  <head>
+    <head-placeholder token="{{ placeholder_token }}">
+    <title>{{ head_title|safe_join(' | ') }}</title>
+    <css-placeholder token="{{ placeholder_token }}">
+    <js-placeholder token="{{ placeholder_token }}">
+  </head>
+  <body{{ attributes.addClass(body_classes) }}>
+    {#
+      Keyboard navigation/accessibility link to main content section in
+      page.html.twig.
+    #}
+    <a href="#main-content" class="visually-hidden focusable skip-link">
+      {{ 'Skip to main content'|t }}
+    </a>
+    {{ page_top }}
+    {{ page }}
+    {{ page_bottom }}
+    <js-bottom-placeholder token="{{ placeholder_token }}">
+  </body>
+</html>

--- a/web/themes/custom/atrium/templates/html/html.html.twig
+++ b/web/themes/custom/atrium/templates/html/html.html.twig
@@ -23,14 +23,12 @@
  * @see template_preprocess_html()
  */
 #}
-{%
-  set body_classes = [
-    logged_in ? 'user-logged-in',
-    not root_path ? 'path-frontpage' : 'path-' ~ root_path|clean_class,
-    node_type ? 'page-node-type-' ~ node_type|clean_class,
-    db_offline ? 'db-offline',
-  ]
-%}
+{% set body_classes = [
+  logged_in ? 'user-logged-in',
+  not root_path ? 'path-frontpage' : 'path-' ~ root_path|clean_class,
+  node_type ? 'page-node-type-' ~ node_type|clean_class,
+  db_offline ? 'db-offline',
+] %}
 <!DOCTYPE html>
 <html{{ html_attributes }}>
   <head>
@@ -40,10 +38,8 @@
     <js-placeholder token="{{ placeholder_token }}">
   </head>
   <body{{ attributes.addClass(body_classes) }}>
-    {#
-      Keyboard navigation/accessibility link to main content section in
-      page.html.twig.
-    #}
+    {# Keyboard navigation/accessibility link to main content section in
+    page.html.twig. #}
     <a href="#main-content" class="visually-hidden focusable skip-link">
       {{ 'Skip to main content'|t }}
     </a>

--- a/web/themes/custom/atrium/templates/html/html.html.twig
+++ b/web/themes/custom/atrium/templates/html/html.html.twig
@@ -43,6 +43,12 @@
     <a href="#main-content" class="visually-hidden focusable skip-link">
       {{ 'Skip to main content'|t }}
     </a>
+
+    {# Icon sprite from Courtyard #}
+    <div style="width:0;height:0;position:absolute;overflow:hidden;">
+      <img src="../../../libraries/courtyard/source/images/icomoon/symbol-defs.svg" alt="" aria-hidden="true">
+    </div>
+
     {{ page_top }}
     {{ page }}
     {{ page_bottom }}

--- a/web/themes/custom/atrium/templates/menu/menu--main.html.twig
+++ b/web/themes/custom/atrium/templates/menu/menu--main.html.twig
@@ -1,0 +1,38 @@
+{#
+/**
+ * @file
+ * Template for main menu.
+ */
+#}
+{% import _self as menus %}
+
+{# We call a macro which calls itself to render the full tree.
+@see https://twig.symfony.com/doc/1.x/tags/macro.html #}
+{{ menus.menu_links(items, attributes, 0) }}
+
+{% macro menu_links(items, attributes, menu_level) %}
+  {% import _self as menus %}
+  {% if items %}
+    {% if menu_level == 0 %}
+      <ul{{ attributes.addClass(['jcc-header_nav', 'slicknav_nav']).setAttribute('id', 'slick-menu') }}>
+    {% else %}
+      <ul class="menu">
+    {% endif %}
+    {% for item in items %}
+      {% set classes = [
+        'jcc-header_nav__item',
+        'slicknav_nav__item',
+        item.is_expanded ? 'jcc-header_nav__item--expanded',
+        item.is_collapsed ? 'jcc-header_nav__item--collapsed',
+        item.in_active_trail ? 'jcc-header_nav__item--active-trail',
+      ] %}
+      <li{{ item.attributes.addClass(classes) }}>
+        {{ link(item.title, item.url) }}
+        {% if item.below %}
+          {{ menus.menu_links(item.below, attributes, menu_level + 1) }}
+        {% endif %}
+      </li>
+    {% endfor %}
+    </ul>
+  {% endif %}
+{% endmacro %}

--- a/web/themes/custom/atrium/templates/menu/menu.html.twig
+++ b/web/themes/custom/atrium/templates/menu/menu.html.twig
@@ -1,0 +1,51 @@
+{#
+/**
+ * @file
+ * Theme override to display a menu.
+ *
+ * Available variables:
+ * - menu_name: The machine name of the menu.
+ * - items: A nested list of menu items. Each menu item contains:
+ *   - attributes: HTML attributes for the menu item.
+ *   - below: The menu item child items.
+ *   - title: The menu link title.
+ *   - url: The menu link url, instance of \Drupal\Core\Url
+ *   - localized_options: Menu link localized options.
+ *   - is_expanded: TRUE if the link has visible children within the current
+ *     menu tree.
+ *   - is_collapsed: TRUE if the link has children within the current menu tree
+ *     that are not currently visible.
+ *   - in_active_trail: TRUE if the link is in the active trail.
+ */
+#}
+{% import _self as menus %}
+
+{# We call a macro which calls itself to render the full tree.
+@see https://twig.symfony.com/doc/1.x/tags/macro.html #}
+{{ menus.menu_links(items, attributes, 0) }}
+
+{% macro menu_links(items, attributes, menu_level) %}
+  {% import _self as menus %}
+  {% if items %}
+    {% if menu_level == 0 %}
+      <ul{{ attributes.addClass('menu') }}>
+    {% else %}
+      <ul class="menu">
+    {% endif %}
+    {% for item in items %}
+      {% set classes = [
+        'menu-item',
+        item.is_expanded ? 'menu-item--expanded',
+        item.is_collapsed ? 'menu-item--collapsed',
+        item.in_active_trail ? 'menu-item--active-trail',
+      ] %}
+      <li{{ item.attributes.addClass(classes) }}>
+        {{ link(item.title, item.url) }}
+        {% if item.below %}
+          {{ menus.menu_links(item.below, attributes, menu_level + 1) }}
+        {% endif %}
+      </li>
+    {% endfor %}
+    </ul>
+  {% endif %}
+{% endmacro %}

--- a/web/themes/custom/atrium/templates/page/page.html.twig
+++ b/web/themes/custom/atrium/templates/page/page.html.twig
@@ -42,49 +42,43 @@
  * @see html.html.twig
  */
 #}
-<div class="layout-container">
+{% set classes = [
+  'page',
+]|merge(classes|default([])) %}
 
-  <header role="banner">
-    {{ page.header }}
-  </header>
+<div{{ attributes.addClass(classes) }}>
+  {% if page.header|render %}
+    <header class="page__header jcc-header" role="banner">
+      <div class="jcc-header__container">
+        <a href="{{ path('<front>') }}" title="{{ 'Home'|t }}" rel="home" class="jcc-header__logo">
+          {% include "@atoms/icons/logo.twig" with {
+            icon: 'logo-group',
+            icon_file: '../../../libraries/courtyard/source/images/icomoon/symbol-defs.svg',
+            title: 'Logo'|t
+          } %}
+        </a>
+        {{ page.header }}
+      </div>
+    </header>
+  {% endif %}
 
-  {{ page.primary_menu }}
-  {{ page.secondary_menu }}
-
-  {{ page.breadcrumb }}
-
-  {{ page.highlighted }}
-
-  {{ page.help }}
+  {% if page.title|render %}
+    <div class="page__title">
+      {{ page.title }}
+    </div>
+  {% endif %}
 
   <main role="main">
-    <a id="main-content" tabindex="-1"></a>
-    {# link is in html.html.twig #}
+    <a id="main-content" tabindex="-1"></a> {# link is in html.html.twig #}
 
-    <div class="layout-content">
+    <div class="page__content">
       {{ page.content }}
     </div>
-    {# /.layout-content #}
-
-    {% if page.sidebar_first %}
-      <aside class="layout-sidebar-first" role="complementary">
-        {{ page.sidebar_first }}
-      </aside>
-    {% endif %}
-
-    {% if page.sidebar_second %}
-      <aside class="layout-sidebar-second" role="complementary">
-        {{ page.sidebar_second }}
-      </aside>
-    {% endif %}
-
   </main>
 
   {% if page.footer %}
-    <footer role="contentinfo">
+    <footer class="page__footer" role="contentinfo">
       {{ page.footer }}
     </footer>
   {% endif %}
-
 </div>
-{# /.layout-container #}

--- a/web/themes/custom/atrium/templates/page/page.html.twig
+++ b/web/themes/custom/atrium/templates/page/page.html.twig
@@ -1,0 +1,90 @@
+{#
+/**
+ * @file
+ * Theme override to display a single page.
+ *
+ * The doctype, html, head and body tags are not in this template. Instead they
+ * can be found in the html.html.twig template in this directory.
+ *
+ * Available variables:
+ *
+ * General utility variables:
+ * - base_path: The base URL path of the Drupal installation. Will usually be
+ *   "/" unless you have installed Drupal in a sub-directory.
+ * - is_front: A flag indicating if the current page is the front page.
+ * - logged_in: A flag indicating if the user is registered and signed in.
+ * - is_admin: A flag indicating if the user has permission to access
+ *   administration pages.
+ *
+ * Site identity:
+ * - front_page: The URL of the front page. Use this instead of base_path when
+ *   linking to the front page. This includes the language domain or prefix.
+ *
+ * Page content (in order of occurrence in the default page.html.twig):
+ * - node: Fully loaded node, if there is an automatically-loaded node
+ *   associated with the page and the node ID is the second argument in the
+ *   page's path (e.g. node/12345 and node/12345/revisions, but not
+ *   comment/reply/12345).
+ *
+ * Regions:
+ * - page.header: Items for the header region.
+ * - page.primary_menu: Items for the primary menu region.
+ * - page.secondary_menu: Items for the secondary menu region.
+ * - page.highlighted: Items for the highlighted content region.
+ * - page.help: Dynamic help text, mostly for admin pages.
+ * - page.content: The main content of the current page.
+ * - page.sidebar_first: Items for the first sidebar.
+ * - page.sidebar_second: Items for the second sidebar.
+ * - page.footer: Items for the footer region.
+ * - page.breadcrumb: Items for the breadcrumb region.
+ *
+ * @see template_preprocess_page()
+ * @see html.html.twig
+ */
+#}
+<div class="layout-container">
+
+  <header role="banner">
+    {{ page.header }}
+  </header>
+
+  {{ page.primary_menu }}
+  {{ page.secondary_menu }}
+
+  {{ page.breadcrumb }}
+
+  {{ page.highlighted }}
+
+  {{ page.help }}
+
+  <main role="main">
+    <a id="main-content" tabindex="-1"></a>
+    {# link is in html.html.twig #}
+
+    <div class="layout-content">
+      {{ page.content }}
+    </div>
+    {# /.layout-content #}
+
+    {% if page.sidebar_first %}
+      <aside class="layout-sidebar-first" role="complementary">
+        {{ page.sidebar_first }}
+      </aside>
+    {% endif %}
+
+    {% if page.sidebar_second %}
+      <aside class="layout-sidebar-second" role="complementary">
+        {{ page.sidebar_second }}
+      </aside>
+    {% endif %}
+
+  </main>
+
+  {% if page.footer %}
+    <footer role="contentinfo">
+      {{ page.footer }}
+    </footer>
+  {% endif %}
+
+</div>
+{# /.layout-container #}

--- a/web/themes/custom/atrium/templates/region/region.html.twig
+++ b/web/themes/custom/atrium/templates/region/region.html.twig
@@ -1,0 +1,15 @@
+{#
+/**
+ * @file
+ * Theme override to display a region.
+ *
+ * Available variables:
+ * - content: The content for this region, typically blocks.
+ * - attributes: HTML attributes for the region <div>.
+ * - region: The name of the region variable as defined in the theme's
+ *   .info.yml file.
+ *
+ * @see template_preprocess_region()
+ */
+#}
+{{ content }}


### PR DESCRIPTION
It's not possible to use any of these components as they've been used in PL, because of things like:

-  The way they're structured: Layout things are not separated from content, and Drupal has a few more layers that would be unwise to remove, e.g.  `<nav>` wrappers on menu blocks that contain ARIA attributes, and visually hidden headings.
- Not much flexibility around the contents, e.g. the [header-nav.twig](https://confident-allen-d061ed.netlify.com/?p=organisms-header) component doesn't allow me to pass in rendered contents, and omit one or more individual components so they can be handled in other templates.
- Menus need to be output with macros and handle children items, which can't happen in a way the the PL and Drupal can both understand without a lot of effort and potentially custom code.

