### PR TITLE
Feature/15420716 howto body

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -137,7 +137,7 @@
         "drupal/xmlsitemap": "^1.0@alpha",
         "drush/drush": "^9.0.0",
         "enyo/dropzone": "^5.5",
-        "exygy/courtyard": "dev-master#958474c",
+        "exygy/courtyard": "dev-master#9eb8416",
         "harvesthq/chosen": "^1.8.7",
         "oomphinc/composer-installers-extender": "^1.1",
         "vlucas/phpdotenv": "^2.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8c773ffc8600e28b392dd944986706fe",
+    "content-hash": "f70a8656cf8c2ab6bb7daf050f977f4e",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -2209,7 +2209,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.9",
-                    "datestamp": "1571249584",
+                    "datestamp": "1548270780",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -5229,7 +5229,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.4",
-                    "datestamp": "1570828084",
+                    "datestamp": "1554239887",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -6762,7 +6762,7 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/exygy/courtyard.git",
-                "reference": "958474c"
+                "reference": "9eb8416"
             },
             "type": "drupal-library"
         },

--- a/web/themes/custom/atrium/templates/field/field--field-howto-tabs.html.twig
+++ b/web/themes/custom/atrium/templates/field/field--field-howto-tabs.html.twig
@@ -1,0 +1,13 @@
+{#
+/**
+ * @file
+ * Template for "HowTo Tabs" field.
+ */
+#}
+<ul role="tablist">
+  {%- for item in items -%}
+    <li role="presentation">
+      {{ item.content }}
+    </li>
+  {%- endfor -%}
+</ul>

--- a/web/themes/custom/atrium/templates/node/node--srl-howto-instruction--full.html.twig
+++ b/web/themes/custom/atrium/templates/node/node--srl-howto-instruction--full.html.twig
@@ -17,7 +17,16 @@
     background_variant: 'has-background-color--light'
   } %}
 
+  <div class="jcc-section-tabs__container">
+    <div class="jcc-header-group__title">
+      {{ content.field_howto_tabs_title }}
+    </div>
+    {{ content.field_howto_tabs }}
+  </div>
+
   {{ content|without(
+    'field_howto_tabs',
+    'field_howto_tabs_title',
     'field_title_display',
     'field_column_first',
     'field_column_second',

--- a/web/themes/custom/atrium/templates/node/node--srl-howto-instruction--full.html.twig
+++ b/web/themes/custom/atrium/templates/node/node--srl-howto-instruction--full.html.twig
@@ -25,6 +25,7 @@
   </div>
 
   {{ content|without(
+    'field_forms',
     'field_howto_tabs',
     'field_howto_tabs_title',
     'field_title_display',

--- a/web/themes/custom/atrium/templates/paragraph/paragraph--judgement-body-tab.html.twig
+++ b/web/themes/custom/atrium/templates/paragraph/paragraph--judgement-body-tab.html.twig
@@ -1,0 +1,37 @@
+{#
+/**
+ * @file
+ * Template for "Judgement Body Tab" Paragraph.
+ *
+ */
+#}
+{% extends 'paragraph.html.twig' %}
+{% block content %}
+
+  {# Create the right column. #}
+  {% set right_column %}
+
+    {% if paragraph.field_display_block.value == 1 %}
+      {# @todo Use courtyard molecules-read-more #}
+      {{ "What is a judgment"|t }}
+      {{ drupal_entity('block_content', 1) }}
+    {% endif %}
+
+    {% set parent = paragraph.getParentEntity() %}
+    {# @todo Also check if field_forms is empty. #}
+    {% if paragraph.field_display_forms.value == 1 %}
+      {{ "Relevant Forms"|t }}
+      {# @todo Use courtyard molecules-filelist .#}
+      {{ parent.field_forms|view }}
+    {% endif %}
+
+  {% endset %}
+
+  {% include '@organisms/sections/text-section/text-section.twig' with {
+    headergroup: { title: paragraph.field_title_display|view },
+    column_content_left: content|without('field_display_block', 'field_display_forms'),
+    column_content_right: right_column,
+    column_variant: 'has-two-columns-threequarter'
+  } only %}
+
+{% endblock %}


### PR DESCRIPTION
- Ask Exygy to change selector from `[role=tablist] a` to a class so markup can be semantic.
- Ask Exygy for an a:active class
- Add JS to hide #p[pid] unless it's in the url.
- Use molecule read-more for Judgement Block
- Use molecule file-list for Relevant Forms
- Check if field_forms is empty before printing forms.