### PR TITLE
use user input entity ids

### DIFF
--- a/web/modules/custom/cc/cc.install
+++ b/web/modules/custom/cc/cc.install
@@ -5,9 +5,6 @@
  * Install, update and uninstall functions for the cc module.
  */
 
-use Drupal\Core\Database\Database;
-use Drupal\Core\Field\BaseFieldDefinition;
-
 /**
  * Implements hook_schema().
  */

--- a/web/modules/custom/cc/cc.module
+++ b/web/modules/custom/cc/cc.module
@@ -109,7 +109,7 @@ function cc_field_widget_form_alter(
       $entity = $field->getEntity();
 
       $widget_state = ConditionalDisplay::getWidgetState(
-        $entity->uuid(), $field_name, $context['delta'], $form_state);
+        $entity->id(), $field_name, $context['delta'], $form_state);
       /** @var ConditionalDisplay $cc */
       if ($widget_state && isset($widget_state['entity'])) {
         $cc = $widget_state['entity'];
@@ -123,7 +123,7 @@ function cc_field_widget_form_alter(
           'entity' => $cc,
         ];
         ConditionalDisplay::setWidgetState(
-          $entity->uuid(), $field_name, $context['delta'], $form_state, $state);
+          $entity->id(), $field_name, $context['delta'], $form_state, $state);
       }
       $element['cc'] = $cc->getWidgetElement($context['form'], $form_state);
 
@@ -235,16 +235,16 @@ function cc_entity_view_alter(
       !$form_state->getErrors()
     ) {
       $user_input = [];
-      $uuids = array_unique(array_map(function ($condition) {
-        return $condition['uuid'];
+      $ids = array_unique(array_map(function ($condition) {
+        return $condition['id'];
       }, $cc->getConditions()->getConditions()));
-      foreach ($uuids as $uuid) {
-        if ($input = $form_state->getValue($uuid)) {
+      foreach ($ids as $id) {
+        if ($input = $form_state->getValue($id)) {
           if (is_array($input)) {
-            $user_input[$uuid] = $input;
+            $user_input[$id] = $input;
           }
           else {
-            $user_input[$uuid] = [$input => $input];
+            $user_input[$id] = [$input => $input];
           }
         }
       }

--- a/web/modules/custom/cc/cc.module
+++ b/web/modules/custom/cc/cc.module
@@ -291,8 +291,6 @@ function cc_entity_view_alter(
 /**
  * Gets/sets a reference to user input form state for later use.
  *
- * @param string $uuid
- *   Entity uuid of the user input entity.
  * @param \Drupal\Core\Form\FormStateInterface $form_state
  *   The form state object.
  *

--- a/web/modules/custom/cc/src/ConditionalDisplay.php
+++ b/web/modules/custom/cc/src/ConditionalDisplay.php
@@ -414,7 +414,7 @@ class ConditionalDisplay {
             $field = $this->hostEntity->get($field_name);
             /** @var \Drupal\cc\Entity\UserInput $user_input */
             foreach ($field->referencedEntities() as $user_input) {
-              $parameter_fields[$field_name][$user_input->uuid()] = [
+              $parameter_fields[$field_name][$user_input->id()] = [
                 'label' => $user_input->label(),
                 'options' => $user_input->getItemsOptions(),
               ];
@@ -430,10 +430,10 @@ class ConditionalDisplay {
   /**
    * Get parameter label.
    */
-  public function getParameterLabel($entity_uuid) {
+  public function getParameterLabel($entity_id) {
     foreach ($this->getParameters() as $field_name => $values) {
-      foreach ($values as $uuid => $value) {
-        if ($uuid == $entity_uuid) {
+      foreach ($values as $id => $value) {
+        if ($id == $entity_id) {
           return $value['label'];
         }
       }
@@ -447,8 +447,8 @@ class ConditionalDisplay {
   public function getParameterKeysOptions() {
     $options = [];
     foreach ($this->getParameters() as $field_name => $values) {
-      foreach ($values as $uuid => $value) {
-        $options[$uuid] = $value['label'];
+      foreach ($values as $id => $value) {
+        $options[$id] = $value['label'];
       }
     }
     return $options;
@@ -457,11 +457,11 @@ class ConditionalDisplay {
   /**
    * Get parameter entity values as select #options array.
    */
-  public function getParameterValuesOptions($entity_uuid) {
+  public function getParameterValuesOptions($entity_id) {
     $options = [];
     foreach ($this->getParameters() as $field_name => $values) {
-      foreach ($values as $uuid => $value) {
-        if ($uuid == $entity_uuid) {
+      foreach ($values as $id => $value) {
+        if ($id == $entity_id) {
           foreach ($value['options'] as $key => $option) {
             $options[$key] = $option;
           }
@@ -502,7 +502,7 @@ class ConditionalDisplay {
 
     $prefix = implode('-', [
       'cc',
-      $this->getHostEntity()->uuid(),
+      $this->getHostEntity()->id(),
       $this->fieldName,
       $this->fieldDelta,
     ]);
@@ -517,7 +517,7 @@ class ConditionalDisplay {
       '#element_validate' => [[get_class($this), 'validateParametersElement']],
       'host_entity' => [
         '#type' => 'value',
-        '#value' => $this->hostEntity->uuid(),
+        '#value' => $this->hostEntity->id(),
       ],
       'field_name' => [
         '#type' => 'value',
@@ -569,10 +569,10 @@ class ConditionalDisplay {
         else {
           $element[$i] = [
             '#type' => 'fieldset',
-            '#title' => $this->getParameterLabel($condition['uuid']),
-            'uuid' => [
+            '#title' => $this->getParameterLabel($condition['id']),
+            'id' => [
               '#type' => 'value',
-              '#value' => $condition['uuid'],
+              '#value' => $condition['id'],
             ],
             'operator' => [
               '#type' => 'select',
@@ -581,7 +581,7 @@ class ConditionalDisplay {
             ],
             'condition' => [
               '#type' => 'checkboxes',
-              '#options' => $this->getParameterValuesOptions($condition['uuid']),
+              '#options' => $this->getParameterValuesOptions($condition['id']),
               '#default_value' => $condition['value'],
             ],
             'remove' => [
@@ -645,16 +645,16 @@ class ConditionalDisplay {
   /**
    * Gets widget state.
    */
-  public static function getWidgetState($entity_uuid, $field_name, $delta, FormStateInterface $form_state) {
-    $parents = ['cc', $entity_uuid, $field_name, $delta];
+  public static function getWidgetState($entity_id, $field_name, $delta, FormStateInterface $form_state) {
+    $parents = ['cc', $entity_id, $field_name, $delta];
     return NestedArray::getValue($form_state->getStorage(), $parents);
   }
 
   /**
    * Sets widget state.
    */
-  public static function setWidgetState($entity_uuid, $field_name, $delta, FormStateInterface $form_state, $value) {
-    $parents = ['cc', $entity_uuid, $field_name, $delta];
+  public static function setWidgetState($entity_id, $field_name, $delta, FormStateInterface $form_state, $value) {
+    $parents = ['cc', $entity_id, $field_name, $delta];
     NestedArray::setValue($form_state->getStorage(), $parents, $value);
   }
 
@@ -794,8 +794,10 @@ class ConditionalDisplay {
         $i = 0;
         while (@$value[$i]) {
           // @todo conditions, nested conditions.
-          $condition->addCondition($value[$i]['uuid'],
-            $value[$i]['operator'], $value[$i]['condition']);
+          if (@$value[$i]['id']) {
+            $condition->addCondition($value[$i]['id'],
+              $value[$i]['operator'], $value[$i]['condition']);
+          }
           $i++;
         }
         return $condition;

--- a/web/modules/custom/cc/src/Conditions.php
+++ b/web/modules/custom/cc/src/Conditions.php
@@ -101,8 +101,8 @@ class Conditions {
   /**
    * Add new condition.
    *
-   * @param string $uuid
-   *   User input entity uuid.
+   * @param string $entity_id
+   *   User input entity id.
    * @param int $operator
    *   One of self::CONDITION_OPERATOR_ONE_OF, self::CONDITION_OPERATOR_ALL_OF.
    * @param array $value
@@ -112,12 +112,12 @@ class Conditions {
    *   For chaining.
    */
   public function addCondition(
-    string $uuid,
+    string $entity_id,
     $operator = self::CONDITION_OPERATOR_NONE_OF,
     array $value = []
   ) {
     $this->conditions[] = [
-      'uuid' => $uuid,
+      'id' => $entity_id,
       'operator' => $operator,
       'value' => $value,
     ];
@@ -207,7 +207,7 @@ class Conditions {
    *   The result.
    */
   protected function evalCondition(array $user_input, array $condition) {
-    $user_input = array_filter($user_input[$condition['uuid']] ?: []);
+    $user_input = array_filter($user_input[$condition['id']] ?: []);
     $values = array_filter($condition['value']);
     switch ($condition['operator']) {
 

--- a/web/modules/custom/cc/src/Form/UserInputForm.php
+++ b/web/modules/custom/cc/src/Form/UserInputForm.php
@@ -68,7 +68,7 @@ class UserInputForm extends FormBase {
       $base_element = [
         '#title' => $entity->label(),
         '#weight' => 10 + $delta,
-        '#default_value' => Drupal::request()->query->get($entity->uuid()) ?: [],
+        '#default_value' => Drupal::request()->query->get($entity->id()) ?: [],
         '#required' => $entity->isRequired(),
       ];
       $options = $entity->getItemsOptions();
@@ -77,13 +77,13 @@ class UserInputForm extends FormBase {
 
         case UserInputInterface::SELECTION_TYPE_RADIO:
           if (count($options)) {
-            $form[$entity->uuid()] = [
+            $form[$entity->id()] = [
               '#type' => 'radios',
               '#options' => $options,
             ] + $base_element;
           }
           else {
-            $form[$entity->uuid()] = [
+            $form[$entity->id()] = [
               '#type' => 'radio',
             ] + $base_element;
           }
@@ -91,20 +91,20 @@ class UserInputForm extends FormBase {
 
         case UserInputInterface::SELECTION_TYPE_CHECKBOX:
           if (count($options)) {
-            $form[$entity->uuid()] = [
+            $form[$entity->id()] = [
               '#type' => 'checkboxes',
               '#options' => $options,
             ] + $base_element;
           }
           else {
-            $form[$entity->uuid()] = [
+            $form[$entity->id()] = [
               '#type' => 'checkbox',
             ] + $base_element;
           }
           break;
 
         case UserInputInterface::SELECTION_TYPE_SELECT:
-          $form[$entity->uuid()] = [
+          $form[$entity->id()] = [
             '#type' => 'select',
             '#options' => $options,
           ] + $base_element;

--- a/web/modules/custom/cc/tests/src/Unit/ConditionsTest.php
+++ b/web/modules/custom/cc/tests/src/Unit/ConditionsTest.php
@@ -31,38 +31,38 @@ class ConditionsTest extends UnitTestCase {
    */
   public function evalDataProvider() {
     $condition_0_true = [
-      'uuid' => 'uuid-0',
+      'id' => 0,
       'operator' => Conditions::CONDITION_OPERATOR_NONE_OF,
       'value' => [
         'item_0' => 'item_0',
       ],
     ];
     $condition_0_false = [
-      'uuid' => 'uuid-0',
+      'id' => 0,
       'operator' => Conditions::CONDITION_OPERATOR_ONE_OF,
       'value' => [
         'item_0' => 'item_0',
       ],
     ];
     $condition_1_true = [
-      'uuid' => 'uuid-1',
+      'id' => 1,
       'operator' => Conditions::CONDITION_OPERATOR_ONE_OF,
       'value' => [
         'item_0' => 'item_0',
       ],
     ];
     $condition_1_false = [
-      'uuid' => 'uuid-1',
+      'id' => 1,
       'operator' => Conditions::CONDITION_OPERATOR_NONE_OF,
       'value' => [
         'item_0' => 'item_0',
       ],
     ];
     $values = [
-      'uuid-0' => [
+      0 => [
         'item_0' => 0,
       ],
-      'uuid-1' => [
+      1 => [
         'item_0' => 'item_0',
       ],
     ];
@@ -161,7 +161,7 @@ class ConditionsTest extends UnitTestCase {
         Conditions::OPERATOR_AND,
         [
           [
-            'uuid' => 'uuid-0',
+            'id' => 0,
             'operator' => Conditions::CONDITION_OPERATOR_NONE_OF,
             'value' => [
               'item_0' => 'item_0',
@@ -171,7 +171,7 @@ class ConditionsTest extends UnitTestCase {
           ],
         ],
         [
-          'uuid-0' => [
+          0 => [
             'item_0' => 'item_0',
             'item_1' => 'item_1',
             'item_2' => 'item_2',
@@ -183,7 +183,7 @@ class ConditionsTest extends UnitTestCase {
         Conditions::OPERATOR_AND,
         [
           [
-            'uuid' => 'uuid-0',
+            'id' => 0,
             'operator' => Conditions::CONDITION_OPERATOR_NONE_OF,
             'value' => [
               'item_0' => 'item_0',
@@ -193,7 +193,7 @@ class ConditionsTest extends UnitTestCase {
           ],
         ],
         [
-          'uuid-0' => [
+          0 => [
             'item_0' => 0,
             'item_1' => 0,
             'item_2' => 0,
@@ -205,7 +205,7 @@ class ConditionsTest extends UnitTestCase {
         Conditions::OPERATOR_AND,
         [
           [
-            'uuid' => 'uuid-0',
+            'id' => 0,
             'operator' => Conditions::CONDITION_OPERATOR_NONE_OF,
             'value' => [
               'item_0' => 0,
@@ -215,7 +215,7 @@ class ConditionsTest extends UnitTestCase {
           ],
         ],
         [
-          'uuid-0' => [
+          0 => [
             'item_0' => 'item_0',
             'item_1' => 'item_1',
             'item_2' => 'item_2',
@@ -227,7 +227,7 @@ class ConditionsTest extends UnitTestCase {
         Conditions::OPERATOR_AND,
         [
           [
-            'uuid' => 'uuid-0',
+            'id' => 0,
             'operator' => Conditions::CONDITION_OPERATOR_NONE_OF,
             'value' => [
               'item_0' => 0,
@@ -237,7 +237,7 @@ class ConditionsTest extends UnitTestCase {
           ],
         ],
         [
-          'uuid-0' => [
+          0 => [
             'item_0' => 0,
             'item_1' => 0,
             'item_2' => 0,
@@ -249,7 +249,7 @@ class ConditionsTest extends UnitTestCase {
         Conditions::OPERATOR_AND,
         [
           [
-            'uuid' => 'uuid-0',
+            'id' => 0,
             'operator' => Conditions::CONDITION_OPERATOR_NONE_OF,
             'value' => [
               'item_0' => 0,
@@ -259,7 +259,7 @@ class ConditionsTest extends UnitTestCase {
           ],
         ],
         [
-          'uuid-0' => [
+          0 => [
             'item_0' => 0,
             'item_1' => 'item_1',
             'item_2' => 0,
@@ -271,7 +271,7 @@ class ConditionsTest extends UnitTestCase {
         Conditions::OPERATOR_AND,
         [
           [
-            'uuid' => 'uuid-0',
+            'id' => 0,
             'operator' => Conditions::CONDITION_OPERATOR_NONE_OF,
             'value' => [
               'item_0' => 'item_0',
@@ -281,7 +281,7 @@ class ConditionsTest extends UnitTestCase {
           ],
         ],
         [
-          'uuid-0' => [
+          0 => [
             'item_0' => 0,
             'item_1' => 'item_1',
             'item_2' => 0,
@@ -293,7 +293,7 @@ class ConditionsTest extends UnitTestCase {
         Conditions::OPERATOR_AND,
         [
           [
-            'uuid' => 'uuid-0',
+            'id' => 0,
             'operator' => Conditions::CONDITION_OPERATOR_NONE_OF,
             'value' => [
               'item_0' => 0,
@@ -303,7 +303,7 @@ class ConditionsTest extends UnitTestCase {
           ],
         ],
         [
-          'uuid-0' => [
+          0 => [
             'item_0' => 'item_0',
             'item_1' => 0,
             'item_2' => 'item_2',
@@ -315,7 +315,7 @@ class ConditionsTest extends UnitTestCase {
         Conditions::OPERATOR_AND,
         [
           [
-            'uuid' => 'uuid-0',
+            'id' => 0,
             'operator' => Conditions::CONDITION_OPERATOR_NONE_OF,
             'value' => [
               'item_0' => 'item_0',
@@ -325,7 +325,7 @@ class ConditionsTest extends UnitTestCase {
           ],
         ],
         [
-          'uuid-0' => [
+          0 => [
             'item_0' => 'item_0',
             'item_1' => 0,
             'item_2' => 'item_2',
@@ -338,7 +338,7 @@ class ConditionsTest extends UnitTestCase {
         Conditions::OPERATOR_AND,
         [
           [
-            'uuid' => 'uuid-0',
+            'id' => 0,
             'operator' => Conditions::CONDITION_OPERATOR_ONE_OF,
             'value' => [
               'item_0' => 'item_0',
@@ -348,7 +348,7 @@ class ConditionsTest extends UnitTestCase {
           ],
         ],
         [
-          'uuid-0' => [
+          0 => [
             'item_0' => 'item_0',
             'item_1' => 'item_1',
             'item_2' => 'item_2',
@@ -360,7 +360,7 @@ class ConditionsTest extends UnitTestCase {
         Conditions::OPERATOR_AND,
         [
           [
-            'uuid' => 'uuid-0',
+            'id' => 0,
             'operator' => Conditions::CONDITION_OPERATOR_ONE_OF,
             'value' => [
               'item_0' => 'item_0',
@@ -370,7 +370,7 @@ class ConditionsTest extends UnitTestCase {
           ],
         ],
         [
-          'uuid-0' => [
+          0 => [
             'item_0' => 0,
             'item_1' => 0,
             'item_2' => 0,
@@ -382,7 +382,7 @@ class ConditionsTest extends UnitTestCase {
         Conditions::OPERATOR_AND,
         [
           [
-            'uuid' => 'uuid-0',
+            'id' => 0,
             'operator' => Conditions::CONDITION_OPERATOR_ONE_OF,
             'value' => [
               'item_0' => 0,
@@ -392,7 +392,7 @@ class ConditionsTest extends UnitTestCase {
           ],
         ],
         [
-          'uuid-0' => [
+          0 => [
             'item_0' => 'item_0',
             'item_1' => 'item_1',
             'item_2' => 'item_2',
@@ -404,7 +404,7 @@ class ConditionsTest extends UnitTestCase {
         Conditions::OPERATOR_AND,
         [
           [
-            'uuid' => 'uuid-0',
+            'id' => 0,
             'operator' => Conditions::CONDITION_OPERATOR_ONE_OF,
             'value' => [
               'item_0' => 0,
@@ -414,7 +414,7 @@ class ConditionsTest extends UnitTestCase {
           ],
         ],
         [
-          'uuid-0' => [
+          0 => [
             'item_0' => 0,
             'item_1' => 0,
             'item_2' => 0,
@@ -426,7 +426,7 @@ class ConditionsTest extends UnitTestCase {
         Conditions::OPERATOR_AND,
         [
           [
-            'uuid' => 'uuid-0',
+            'id' => 0,
             'operator' => Conditions::CONDITION_OPERATOR_ONE_OF,
             'value' => [
               'item_0' => 0,
@@ -436,7 +436,7 @@ class ConditionsTest extends UnitTestCase {
           ],
         ],
         [
-          'uuid-0' => [
+          0 => [
             'item_0' => 0,
             'item_1' => 'item_1',
             'item_2' => 0,
@@ -448,7 +448,7 @@ class ConditionsTest extends UnitTestCase {
         Conditions::OPERATOR_AND,
         [
           [
-            'uuid' => 'uuid-0',
+            'id' => 0,
             'operator' => Conditions::CONDITION_OPERATOR_ONE_OF,
             'value' => [
               'item_0' => 'item_0',
@@ -458,7 +458,7 @@ class ConditionsTest extends UnitTestCase {
           ],
         ],
         [
-          'uuid-0' => [
+          0 => [
             'item_0' => 0,
             'item_1' => 'item_1',
             'item_2' => 0,
@@ -470,7 +470,7 @@ class ConditionsTest extends UnitTestCase {
         Conditions::OPERATOR_AND,
         [
           [
-            'uuid' => 'uuid-0',
+            'id' => 0,
             'operator' => Conditions::CONDITION_OPERATOR_ONE_OF,
             'value' => [
               'item_0' => 0,
@@ -480,7 +480,7 @@ class ConditionsTest extends UnitTestCase {
           ],
         ],
         [
-          'uuid-0' => [
+          0 => [
             'item_0' => 'item_0',
             'item_1' => 0,
             'item_2' => 'item_2',
@@ -492,7 +492,7 @@ class ConditionsTest extends UnitTestCase {
         Conditions::OPERATOR_AND,
         [
           [
-            'uuid' => 'uuid-0',
+            'id' => 0,
             'operator' => Conditions::CONDITION_OPERATOR_ONE_OF,
             'value' => [
               'item_0' => 'item_0',
@@ -502,7 +502,7 @@ class ConditionsTest extends UnitTestCase {
           ],
         ],
         [
-          'uuid-0' => [
+          0 => [
             'item_0' => 'item_0',
             'item_1' => 0,
             'item_2' => 'item_2',
@@ -515,7 +515,7 @@ class ConditionsTest extends UnitTestCase {
         Conditions::OPERATOR_AND,
         [
           [
-            'uuid' => 'uuid-0',
+            'id' => 0,
             'operator' => Conditions::CONDITION_OPERATOR_ALL_OF,
             'value' => [
               'item_0' => 'item_0',
@@ -525,7 +525,7 @@ class ConditionsTest extends UnitTestCase {
           ],
         ],
         [
-          'uuid-0' => [
+          0 => [
             'item_0' => 'item_0',
             'item_1' => 'item_1',
             'item_2' => 'item_2',
@@ -537,7 +537,7 @@ class ConditionsTest extends UnitTestCase {
         Conditions::OPERATOR_AND,
         [
           [
-            'uuid' => 'uuid-0',
+            'id' => 0,
             'operator' => Conditions::CONDITION_OPERATOR_ALL_OF,
             'value' => [
               'item_0' => 'item_0',
@@ -547,7 +547,7 @@ class ConditionsTest extends UnitTestCase {
           ],
         ],
         [
-          'uuid-0' => [
+          0 => [
             'item_0' => 0,
             'item_1' => 0,
             'item_2' => 0,
@@ -559,7 +559,7 @@ class ConditionsTest extends UnitTestCase {
         Conditions::OPERATOR_AND,
         [
           [
-            'uuid' => 'uuid-0',
+            'id' => 0,
             'operator' => Conditions::CONDITION_OPERATOR_ALL_OF,
             'value' => [
               'item_0' => 0,
@@ -569,7 +569,7 @@ class ConditionsTest extends UnitTestCase {
           ],
         ],
         [
-          'uuid-0' => [
+          0 => [
             'item_0' => 'item_0',
             'item_1' => 'item_1',
             'item_2' => 'item_2',
@@ -581,7 +581,7 @@ class ConditionsTest extends UnitTestCase {
         Conditions::OPERATOR_AND,
         [
           [
-            'uuid' => 'uuid-0',
+            'id' => 0,
             'operator' => Conditions::CONDITION_OPERATOR_ALL_OF,
             'value' => [
               'item_0' => 0,
@@ -591,7 +591,7 @@ class ConditionsTest extends UnitTestCase {
           ],
         ],
         [
-          'uuid-0' => [
+          0 => [
             'item_0' => 0,
             'item_1' => 0,
             'item_2' => 0,
@@ -603,7 +603,7 @@ class ConditionsTest extends UnitTestCase {
         Conditions::OPERATOR_AND,
         [
           [
-            'uuid' => 'uuid-0',
+            'id' => 0,
             'operator' => Conditions::CONDITION_OPERATOR_ALL_OF,
             'value' => [
               'item_0' => 0,
@@ -613,7 +613,7 @@ class ConditionsTest extends UnitTestCase {
           ],
         ],
         [
-          'uuid-0' => [
+          0 => [
             'item_0' => 0,
             'item_1' => 'item_1',
             'item_2' => 0,
@@ -625,7 +625,7 @@ class ConditionsTest extends UnitTestCase {
         Conditions::OPERATOR_AND,
         [
           [
-            'uuid' => 'uuid-0',
+            'id' => 0,
             'operator' => Conditions::CONDITION_OPERATOR_ALL_OF,
             'value' => [
               'item_0' => 'item_0',
@@ -635,7 +635,7 @@ class ConditionsTest extends UnitTestCase {
           ],
         ],
         [
-          'uuid-0' => [
+          0 => [
             'item_0' => 0,
             'item_1' => 'item_1',
             'item_2' => 0,
@@ -647,7 +647,7 @@ class ConditionsTest extends UnitTestCase {
         Conditions::OPERATOR_AND,
         [
           [
-            'uuid' => 'uuid-0',
+            'id' => 0,
             'operator' => Conditions::CONDITION_OPERATOR_ALL_OF,
             'value' => [
               'item_0' => 0,
@@ -657,7 +657,7 @@ class ConditionsTest extends UnitTestCase {
           ],
         ],
         [
-          'uuid-0' => [
+          0 => [
             'item_0' => 'item_0',
             'item_1' => 0,
             'item_2' => 'item_2',
@@ -669,7 +669,7 @@ class ConditionsTest extends UnitTestCase {
         Conditions::OPERATOR_AND,
         [
           [
-            'uuid' => 'uuid-0',
+            'id' => 0,
             'operator' => Conditions::CONDITION_OPERATOR_ALL_OF,
             'value' => [
               'item_0' => 'item_0',
@@ -679,7 +679,7 @@ class ConditionsTest extends UnitTestCase {
           ],
         ],
         [
-          'uuid-0' => [
+          0 => [
             'item_0' => 'item_0',
             'item_1' => 0,
             'item_2' => 'item_2',

--- a/web/modules/custom/srl_updates/srl_updates.install
+++ b/web/modules/custom/srl_updates/srl_updates.install
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @file Module install file.
+ */
+
+use Drupal\cc\Conditions;
+
+/**
+ * Convert to cc module user input id from uuid.
+ */
+function srl_updates_update_8001(&$sandbox) {
+  $storage = Drupal::entityTypeManager()->getStorage('cc_user_input');
+
+  $database = Drupal::database();
+  $query = $database
+    ->select('cc_field_conditions', 'fc')
+    ->fields('fc');
+  foreach ($query->execute() as $row) {
+    $save = FALSE;
+    /** @var \Drupal\cc\Conditions $conditions */
+    $conditions = unserialize($row->conditions);
+    $conditions_array = $conditions->getConditions();
+    foreach ($conditions_array as $i => &$condition) {
+      $save = TRUE;
+      /** @var \Drupal\cc\Entity\UserInput $entity */
+      if (empty($condition['uuid']) ||
+        !($entity = reset($storage->loadByProperties(['uuid' => $condition['uuid']])))
+      ) {
+        unset($conditions_array[$i]);
+      }
+      else {
+        unset($condition['uuid']);
+        $condition['id'] = $entity->id();
+      }
+    }
+    if ($save) {
+      $conditions = new Conditions($conditions->getOperator(), array_values($conditions_array));
+      $database
+        ->merge('cc_field_conditions')
+        ->keys([
+          'entity_type' => $row->entity_type,
+          'entity_id' => $row->entity_id,
+          'revision_id' => $row->revision_id,
+          'langcode' => $row->langcode,
+          'field' => $row->field,
+          'delta' => $row->delta,
+        ])
+        ->fields([
+          'conditions' => serialize($conditions),
+        ])
+        ->execute();
+    }
+  }
+}


### PR DESCRIPTION
some refactoring required for adding ids to user input items

this changes user input entity references from uuid to entity id's, which also has the side effect of cleaner urls