### PR TITLE
[TW15702094] Entity Clone Customization and Permissions Update

### DIFF
--- a/config/config-default/entity_clone.settings.yml
+++ b/config/config-default/entity_clone.settings.yml
@@ -2,35 +2,35 @@ form_settings:
   block_content:
     default_value: true
     disable: true
-    hidden: true
+    hidden: false
   cc_user_input:
     default_value: true
     disable: true
-    hidden: true
+    hidden: false
   file:
-    default_value: false
     disable: true
-    hidden: true
+    default_value: false
+    hidden: false
   media:
-    default_value: false
     disable: true
-    hidden: true
+    default_value: false
+    hidden: false
   node:
     default_value: true
     disable: true
-    hidden: true
+    hidden: false
   taxonomy_term:
-    default_value: false
     disable: true
-    hidden: true
+    default_value: false
+    hidden: false
   menu_link_content:
     default_value: true
     disable: true
-    hidden: true
+    hidden: false
   paragraph:
     default_value: true
     disable: true
-    hidden: true
+    hidden: false
   crop:
     default_value: false
     disable: false

--- a/config/config-default/entity_clone.settings.yml
+++ b/config/config-default/entity_clone.settings.yml
@@ -1,0 +1,53 @@
+form_settings:
+  block_content:
+    default_value: true
+    disable: true
+    hidden: true
+  cc_user_input:
+    default_value: true
+    disable: true
+    hidden: true
+  file:
+    default_value: false
+    disable: true
+    hidden: true
+  media:
+    default_value: false
+    disable: true
+    hidden: true
+  node:
+    default_value: true
+    disable: true
+    hidden: true
+  taxonomy_term:
+    default_value: false
+    disable: true
+    hidden: true
+  menu_link_content:
+    default_value: true
+    disable: true
+    hidden: true
+  paragraph:
+    default_value: true
+    disable: true
+    hidden: true
+  crop:
+    default_value: false
+    disable: false
+    hidden: false
+  entity_embed_fake_entity:
+    default_value: false
+    disable: false
+    hidden: false
+  redirect:
+    default_value: false
+    disable: false
+    hidden: false
+  shortcut:
+    default_value: false
+    disable: false
+    hidden: false
+  user:
+    default_value: false
+    disable: false
+    hidden: false

--- a/config/config-default/user.role.editor.yml
+++ b/config/config-default/user.role.editor.yml
@@ -20,7 +20,6 @@ permissions:
   - 'change own username'
   - 'clone node entity'
   - 'clone paragraph entity'
-  - 'clone taxonomy_term entity'
   - 'create audio media'
   - 'create content translations'
   - 'create file media'

--- a/config/config-default/user.role.jcc_web_services.yml
+++ b/config/config-default/user.role.jcc_web_services.yml
@@ -40,7 +40,6 @@ permissions:
   - 'change own username'
   - 'clone node entity'
   - 'clone paragraph entity'
-  - 'clone taxonomy_term entity'
   - 'create audio media'
   - 'create basic content'
   - 'create content translations'


### PR DESCRIPTION
This PR simplifies the UX for the entities below, and forces the following behavior when cloned:

## Reference child items

- file
- media
- taxonomy_term

## Duplicate child items

- block_content
- cc_user_input
- node
- menu_link_content
- paragraph

The remaining entities were left using the module defaults.  